### PR TITLE
Fix build and update examples

### DIFF
--- a/examples/continuous-time/bower.json
+++ b/examples/continuous-time/bower.json
@@ -7,18 +7,17 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.2.0",
-    "purescript-console": "^3.0.0",
-    "purescript-functions": "^3.0.0",
-    "purescript-dom": "^4.15.0",
-    "purescript-monoid": "^3.3.0",
-    "purescript-record": "^0.2.6",
-    "purescript-strings": "^3.5.0",
-    "purescript-js-date": "^5.2.0",
-    "purescript-hareactive": "^0.0.2"
+    "purescript-prelude": "^4.1.0",
+    "purescript-console": "^4.1.0",
+    "purescript-functions": "^4.0.0",
+    "purescript-record": "^1.0.0",
+    "purescript-strings": "^4.0.0",
+    "purescript-js-date": "^6.0.0",
+    "purescript-hareactive": "^0.0.5",
+    "purescript-turbine": "../.."
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^4.0.0"
   },
   "resolutions": {
     "purescript-js-date": "^5.2.0"

--- a/examples/continuous-time/src/Main.purs
+++ b/examples/continuous-time/src/Main.purs
@@ -2,8 +2,8 @@ module Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Hareactive (Behavior, Stream, Now, time, sample, stepper, snapshot)
+import Hareactive.Types (Behavior, Stream, Now)
+import Hareactive.Combinators (time, sample, stepper, snapshot)
 import Data.Array (head)
 import Data.Maybe (fromMaybe)
 import Data.String (split, Pattern(..))
@@ -29,7 +29,7 @@ appModel { snapClick } _ = do
   message <- sample $ stepper "You've not clicked the button yet" msgFromClick
   pure {time, message}
 
-appView :: AppModelOut -> Component _ AppViewOut
+appView :: AppModelOut -> Unit -> Component _ AppViewOut
 appView { message, time } _ =
   E.h1_ (E.text "Continuous") </>
   E.p_ (E.textB $ formatTime <$> time) </>
@@ -38,5 +38,4 @@ appView { message, time } _ =
 
 app = modelView appModel appView unit
 
-main :: Eff _ Unit
 main = runComponent "#mount" app

--- a/examples/counters/bower.json
+++ b/examples/counters/bower.json
@@ -10,7 +10,7 @@
     "purescript-prelude": "^4.1.0",
     "purescript-functions": "^4.0.0",
     "purescript-record": "^1.0.0",
-    "purescript-hareactive": "^0.0.4",
+    "purescript-hareactive": "^0.0.5",
     "purescript-turbine": "../../"
   },
   "devDependencies": {

--- a/examples/counters/src/Main.purs
+++ b/examples/counters/src/Main.purs
@@ -5,7 +5,8 @@ import Prelude
 import Effect (Effect)
 import Counters.Version1 as Version1
 import Counters.Version2 as Version2
-import Hareactive (Behavior, Stream, Now, sample, stepper)
+import Hareactive.Types (Behavior, Stream, Now)
+import Hareactive.Combinators (sample, stepper)
 import Turbine (Component, runComponent, dynamic, output, modelView, (</>))
 import Turbine.HTML.Elements as E
 
@@ -27,8 +28,8 @@ type AppViewOut =
   , selectVersion2 :: Stream Version
   }
 
-appView :: AppModelOut -> Component _ AppViewOut
-appView out =
+appView :: AppModelOut -> Unit -> Component _ AppViewOut
+appView out _ =
   E.button_ (E.text "Version 1") `output` (\o -> { selectVersion1: o.click $> One }) </>
   E.button_ (E.text "Version 2") `output` (\o -> { selectVersion2: o.click $> Two }) </>
   (dynamic out.version)

--- a/examples/counters/src/Version1.purs
+++ b/examples/counters/src/Version1.purs
@@ -7,7 +7,8 @@ import Prelude
 import Control.Apply (lift2)
 import Data.Array (cons, filter)
 import Data.Foldable (fold, foldr)
-import Hareactive (Behavior, Stream, Now, sample, scan, scanS, switchStream)
+import Hareactive.Types (Behavior, Stream, Now)
+import Hareactive.Combinators (sample, scan, scanS, switchStream)
 import Data.Monoid ((<>))
 import Turbine (Component, runComponent, output, modelView, (</>), list)
 import Turbine.HTML.Elements as E
@@ -21,7 +22,7 @@ counterModel { increment, decrement } id = do
   count <- sample $ scan (+) 0 changes
   pure { count }
 
-counterView :: CounterOut -> Component _ CounterViewOut
+counterView :: CounterOut -> Int -> Component _ CounterViewOut
 counterView {count} _ =
   E.div_ (
     E.text "Counter " </>

--- a/examples/counters/src/Version2.purs
+++ b/examples/counters/src/Version2.purs
@@ -28,7 +28,7 @@ counterModel { increment, decrement, delete } id = do
   count <- sample $ scan (+) 0 changes
   pure { count, delete: delete $> id }
 
---counterView :: CounterOut -> Unit -> Component CounterViewOut CounterViewOut
+counterView :: CounterOut -> Int -> Component CounterViewOut CounterViewOut
 counterView { count } _ =
   E.div { class: E.staticClass "foo bar" } (
     E.text "Counter " </>
@@ -63,7 +63,7 @@ counterListModel { addCounter, listOut } init = do
   counterIds <- sample $ scan ($) init (appendCounter <> removeCounter)
   pure { sum, counterIds }
 
---counterListView :: ListOut -> Array Int -> Component _ ListViewOut
+counterListView :: ListOut -> Array Int -> Component _ ListViewOut
 counterListView { sum, counterIds } _ =
   E.div_ (
     E.h1_ (E.text "Counters") </>

--- a/examples/counters/src/Version2.purs
+++ b/examples/counters/src/Version2.purs
@@ -7,7 +7,8 @@ import Prelude
 import Control.Apply (lift2)
 import Data.Array (cons, filter)
 import Data.Foldable (fold, foldr)
-import Hareactive (Behavior, Stream, Now, sample, scan, scanS, switchStream)
+import Hareactive.Types (Behavior, Stream, Now)
+import Hareactive.Combinators (sample, scan, scanS, switchStream)
 import Turbine (Component, list, modelView, output, static, (</>))
 import Turbine.HTML.Elements as E
 
@@ -27,9 +28,9 @@ counterModel { increment, decrement, delete } id = do
   count <- sample $ scan (+) 0 changes
   pure { count, delete: delete $> id }
 
-counterView :: CounterOut -> Component CounterViewOut CounterViewOut
+--counterView :: CounterOut -> Unit -> Component CounterViewOut CounterViewOut
 counterView { count } _ =
-  E.div (static { class: "foo bar" }) (
+  E.div { class: E.staticClass "foo bar" } (
     E.text "Counter " </>
     E.span_ (E.textB $ map show count) </>
     E.button_ (E.text "+") `output` (\o -> { increment: o.click }) </>
@@ -62,7 +63,7 @@ counterListModel { addCounter, listOut } init = do
   counterIds <- sample $ scan ($) init (appendCounter <> removeCounter)
   pure { sum, counterIds }
 
-counterListView :: ListOut -> Component _ ListViewOut
+--counterListView :: ListOut -> Array Int -> Component _ ListViewOut
 counterListView { sum, counterIds } _ =
   E.div_ (
     E.h1_ (E.text "Counters") </>

--- a/examples/fahrenheit-celsius/bower.json
+++ b/examples/fahrenheit-celsius/bower.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-hareactive": "^0.0.3",
+    "purescript-hareactive": "^0.0.5",
     "purescript-web-events": "^1.0.0",
     "purescript-numbers": "^6.0.0"
   }

--- a/examples/fahrenheit-celsius/src/Main.purs
+++ b/examples/fahrenheit-celsius/src/Main.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Data.Number (fromString)
 import Effect (Effect)
-import Hareactive (Behavior, Stream, Now, changes, filterJust, sample, stepper)
+import Hareactive.Types (Behavior, Stream, Now)
+import Hareactive.Combinators (changes, filterJust, sample, stepper)
 import Turbine (Component, modelView, output, runComponent, (</>))
 import Turbine.HTML.Elements as E
 import Turbine.HTML.Properties as P
@@ -33,16 +34,16 @@ appModel { fahrenChange, celsiusChange } _ =
     fahren <- sample $ stepper 0.0 (fahrenNrChange <> (celsiusToFahren <$> celsiusNrChange))
     pure { fahren, celsius }
 
-appView :: AppModelOut -> Component _ _
+appView :: AppModelOut -> Unit -> Component _ _
 appView { celsius, fahren } _ =
   E.div_ (
     E.div_ (
-      E.label_ (E.text "Fahrenheit") </>
-      E.input [ P.attribute "value" fahren ] `output` (\o -> { fahrenInput: o.inputValue })
+      E.label_ (E.text "Fahrenheit") </> --[ P.attribute "value" fahren ]
+      E.input { value: show <$> fahren } `output` (\o -> { fahrenInput: o.inputValue })
     ) </>
     E.div_ (
-      E.label_ (E.text "Celsius") </>
-      E.input [ P.attribute "value" celsius ] `output` (\o -> { celsiusInput: o.inputValue })
+      E.label_ (E.text "Celsius") </> --[ P.attribute "value" celsius ]
+      E.input { value: show <$> celsius } `output` (\o -> { celsiusInput: o.inputValue })
     )
   ) `output` (\o -> { fahrenChange: changes o.fahrenInput, celsiusChange: changes o.celsiusInput })
 

--- a/examples/todomvc/bower.json
+++ b/examples/todomvc/bower.json
@@ -12,7 +12,7 @@
     "purescript-functions": "^4.0.0",
     "purescript-record": "^1.0.0",
     "purescript-strings": "^4.0.0",
-    "purescript-hareactive": "^0.0.4",
+    "purescript-hareactive": "^0.0.5",
     "purescript-turbine": "../../",
     "purescript-arrays": "^5.0.0",
     "purescript-foldable-traversable": "^4.0.0"

--- a/examples/zip-codes/bower.json
+++ b/examples/zip-codes/bower.json
@@ -12,12 +12,12 @@
     "purescript-functions": "^4.0.0",
     "purescript-record": "^1.0.0",
     "purescript-strings": "^4.0.0",
-    "purescript-hareactive": "^0.0.4",
+    "purescript-hareactive": "^0.0.5",
     "purescript-turbine": "../../"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-hareactive": "^0.0.4",
+    "purescript-hareactive": "^0.0.5",
     "purescript-web-events": "^1.0.0",
     "purescript-numbers": "^6.0.0",
     "purescript-affjax": "^6.0.0",

--- a/examples/zip-codes/src/Main.purs
+++ b/examples/zip-codes/src/Main.purs
@@ -13,7 +13,8 @@ import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Partial.Unsafe (unsafePartial)
 import Data.Tuple (Tuple(..))
-import Hareactive (Behavior, Stream, Now, changes, split, filterJust, sample, stepper, filter, runStreamAff)
+import Hareactive.Types (Behavior, Stream, Now)
+import Hareactive.Combinators (changes, split, filterJust, sample, stepper, filter, runStreamAff)
 import Network.HTTP.Affjax as AX
 import Network.HTTP.Affjax.Response as AXRes
 import Network.HTTP.StatusCode (StatusCode(..))
@@ -60,7 +61,7 @@ zipModel { zipCode } _ = do
   status <- sample $ stepper "" statusChange
   pure { status }
 
-zipView { status } =
+zipView { status } _ =
   E.div_ (
     E.span_ (E.text "Please type a valid US zip code: ") </>
     E.input (static { placeholder: "Zip code" }) `output` (\o -> { zipCode: o.inputValue }) </>

--- a/src/Turbine/HTML/Elements.purs
+++ b/src/Turbine/HTML/Elements.purs
@@ -139,10 +139,10 @@ ul_ = ul {}
 
 foreign import _ul :: forall a o p. Subrow a Attributes => Fn2 (Record a) (Component o p) (Component o Output)
 
-li :: forall a o p. Subrow a Attributes => Record a -> Component o p -> Component o o
+li :: forall a o p. Subrow a Attributes => Record a -> Component o p -> Component o Output
 li = runFn2 _li
 
-li_ :: forall o p. Component o p -> Component o o
+li_ :: forall o p. Component o p -> Component o Output
 li_ = li {}
 
 foreign import _li :: forall a o p. Subrow a Attributes => Fn2 (Record a) (Component o p) (Component o Output)


### PR DESCRIPTION
`li` needed to `Output` in its type before it could build.

I've updated the examples to the latest version.