### PR TITLE
Add tables

### DIFF
--- a/src/Turbine/HTML/Elements.js
+++ b/src/Turbine/HTML/Elements.js
@@ -74,6 +74,23 @@ exports._section = function() {
     return T.elements.section;
 };
 
+exports._table = function() {
+    return T.elements.table;
+};
+
+exports._th = function() {
+    return T.elements.th;
+};
+
+exports._tr = function() {
+    return T.elements.tr;
+};
+
+exports._td = function() {
+    return T.elements.td;
+};
+
+
 exports._text = T.text;
 
 exports._textB = T.dynamic;

--- a/src/Turbine/HTML/Elements.purs
+++ b/src/Turbine/HTML/Elements.purs
@@ -30,6 +30,14 @@ module Turbine.HTML.Elements
   , header_
   , footer
   , footer_
+  , table
+  , table_
+  , th
+  , th_
+  , tr
+  , tr_
+  , td
+  , td_
   , class Subrow
   , class RecordOf
   , class RecordOfGo
@@ -295,6 +303,38 @@ textB :: Behavior String -> Component {} Unit
 textB = _textB
 
 foreign import _textB :: Behavior String -> Component {} Unit
+
+table :: forall a o p. Subrow a Attributes => Record a -> Component o p -> Component o Output
+table = runFn2 _table
+
+table_ :: forall o p. Component o p -> Component o Output
+table_ = table {}
+
+foreign import _table :: forall a o p. Subrow a Attributes => Fn2 (Record a) (Component o p) (Component o Output)
+
+th :: forall a o p. Subrow a Attributes => Record a -> Component o p -> Component o Output
+th = runFn2 _th
+
+th_ :: forall o p. Component o p -> Component o Output
+th_ = th {}
+
+foreign import _th :: forall a o p. Subrow a Attributes => Fn2 (Record a) (Component o p) (Component o Output)
+
+tr :: forall a o p. Subrow a Attributes => Record a -> Component o p -> Component o Output
+tr = runFn2 _tr
+
+tr_ :: forall o p. Component o p -> Component o Output
+tr_ = tr {}
+
+foreign import _tr :: forall a o p. Subrow a Attributes => Fn2 (Record a) (Component o p) (Component o Output)
+
+td :: forall a o p. Subrow a Attributes => Record a -> Component o p -> Component o Output
+td = runFn2 _td
+
+td_ :: forall o p. Component o p -> Component o Output
+td_ = td {}
+
+foreign import _td :: forall a o p. Subrow a Attributes => Fn2 (Record a) (Component o p) (Component o Output)
 
 foreign import br :: Component {} Unit
 


### PR DESCRIPTION
Needed tables for what I was doing, and they weren't there yet.

By the way, how do you fold with `</>`? I tried something like the following:

```purs
foldl (</>) (E.th_ (E.text "")) $ map (E.th_ <<< E.text <<< show) (0..10)
```

But this does not typecheck. Looks like the problem is right here:

```purs
foldl (</>) (E.th_ (E.text ""))
```
Error:

```
Could not match type
                                     
    ( click :: Stream Unit           
    , dblclick :: Stream Unit        
    , keydown :: Stream KeyboardEvent
    , keyup :: Stream KeyboardEvent  
    , blur :: Stream FocusEvent      
    )                                
                                     
  with type
      
    ()
      

while trying to match type { click :: Stream Unit           
                           , dblclick :: Stream Unit        
                           , keydown :: Stream KeyboardEvent
                           , keyup :: Stream KeyboardEvent  
                           , blur :: Stream FocusEvent      
                           }                                
  with type { | t0 }
while checking that expression th_ (text "")
  has type Component { | t0 } { | t0 }
```
