### PR TITLE
Export `a`

### DIFF
--- a/src/Turbine/HTML.purs
+++ b/src/Turbine/HTML.purs
@@ -11,6 +11,7 @@ module Turbine.HTML
   , div
   , br
   , p
+  , a
   , text
   , textB
   , ul


### PR DESCRIPTION
It's weird that `a` is never exported 😅